### PR TITLE
Make challenge card sticky

### DIFF
--- a/src/app/game/page.tsx
+++ b/src/app/game/page.tsx
@@ -318,10 +318,10 @@ export default function Game() {
       </div>
       
       {gameState.currentChallenge && (
-        <div className="mt-6">
+        <div className="mt-6 sticky top-0 z-20 bg-white">
           <ChallengeCard challenge={gameState.currentChallenge} />
-          <ChallengeStatus 
-            status={gameState.challengeStatus} 
+          <ChallengeStatus
+            status={gameState.challengeStatus}
             statusLevel={gameState.challengeStatusLevel}
             typingSpeed={20} // 少し速めのタイピング速度
           />


### PR DESCRIPTION
## Summary
- ensure the challenge header remains visible
- keep page background when sticky

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run dev` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f580186a8832988925284642e6fc0